### PR TITLE
efficiency improvements for computation of cheb wgts

### DIFF
--- a/chebyshev/Cheb_LDoS.m
+++ b/chebyshev/Cheb_LDoS.m
@@ -8,8 +8,8 @@
 % Output will be an array LDoS, where LDoS is a function of energy
 % mathematically.
 
-function ldos = Cheb_LDoS(H, v, P, E)
-cheb_weights = Cheb_LDoS_Weights(H, v, P);
+function [ldos,cheb_weights] = Cheb_LDoS(H, E_range, v, P, E)
+cheb_weights = Cheb_LDoS_Weights(H, E_range, v, P);
 jackson_coeff = Cheb_JacksonCoeff(P);
 measure_weight = 1./sqrt(1 - E.^2);
 cheb_energy = Cheb_Eval(E, P);

--- a/chebyshev/Cheb_LDoS_Weights.m
+++ b/chebyshev/Cheb_LDoS_Weights.m
@@ -3,17 +3,17 @@
 % computes < v | T_n(H) | v > for all n <= P and returns it in an array of
 % size P+1, coefficients n = 0, 1, . . . P.
 
-function Cheb_Coeff = Cheb_LDoS_Weights(H, v, P)
+function Cheb_Coeff = Cheb_LDoS_Weights(H, E_range, v, P)
 
 v_1 = v;
-v_2 = H*v;
+v_2 = (H*v)/E_range;
 
 Cheb_Coeff = zeros(1,P+1);
 Cheb_Coeff(1) = v'*v_1;         % compute first two Chebyshev LDoS weights
 Cheb_Coeff(2) = v'*v_2;
 
 for j = 2:P
-    v_new = 2*H*v_2 - v_1;
+    v_new = (2/E_range)*(H*v_2) - v_1;
     Cheb_Coeff(j+1) = v'*v_new;
     v_1 = v_2;
     v_2 = v_new;


### PR DESCRIPTION
- Avoid multiplying sparse matrix by scalar in each iteration of Chebyshev recurrence
- Dump out cheb weights explicitly in dos_compute.m
- A couple of other minor changes